### PR TITLE
Alee/drift radiator draft

### DIFF
--- a/assets/js/driftRadiator.js
+++ b/assets/js/driftRadiator.js
@@ -6,6 +6,7 @@ const data = Object.fromEntries(environments.map(e => [`${e}`, undefined]))
 const updateVersion = ({ env, version, date, build, sha }) => {
   data[env] = { version, date, build, sha }
   $(`#${env}_build`).text(build)
+  $(`#${env}_date`).text(date)
 
   if (env != devEnvName && data[devEnvName]) {
     const devEnvSha = data[devEnvName].sha
@@ -16,16 +17,14 @@ const updateVersion = ({ env, version, date, build, sha }) => {
 
     const humanReadableDate = `${dayjs(devEnvDate).diff(thisEnvDate, 'day')} days behind dev`
 
-    $(`#${env}_date`).text(`${date} (${humanReadableDate})`)
-
     if (devEnvSha !== thisEnvSha) {
       $(`#${env}_details`).html(`
+      
+      <strong>Staleness:</strong> ${humanReadableDate}<br/>
       <strong>Differences:</strong>
       <a class="govuk-link--no-visited-state" href="https://github.com/ministryofjustice/${componentName}/compare/${thisEnvSha}...${devEnvSha}">View in GitHub</a>
     `)
     }
-  } else {
-    $(`#${env}_date`).text(date)
   }
 }
 

--- a/assets/js/driftRadiator.js
+++ b/assets/js/driftRadiator.js
@@ -1,0 +1,70 @@
+dayjs.extend(window.dayjs_plugin_relativeTime)
+
+const lastIds = Object.fromEntries(environments.map(e => [`v:${e}`, 0]))
+const data = Object.fromEntries(environments.map(e => [`${e}`, undefined]))
+
+const updateVersion = ({ env, version, date, build, sha }) => {
+  data[env] = { version, date, build, sha }
+  $(`#${env}_build`).text(build)
+
+  if (env != devEnvName && data[devEnvName]) {
+    const devEnvSha = data[devEnvName].sha
+    const thisEnvSha = data[env].sha
+
+    const devEnvDate = data[devEnvName].date
+    const thisEnvDate = data[env].date
+
+    const humanReadableDate = `${dayjs(devEnvDate).diff(thisEnvDate, 'day')} days behind dev`
+
+    $(`#${env}_date`).text(`${date} (${humanReadableDate})`)
+
+    if (devEnvSha !== thisEnvSha) {
+      $(`#${env}_details`).html(`
+      <strong>Differences:</strong>
+      <a class="govuk-link--no-visited-state" href="https://github.com/ministryofjustice/${componentName}/compare/${thisEnvSha}...${devEnvSha}">View in GitHub</a>
+    `)
+    }
+  } else {
+    $(`#${env}_date`).text(date)
+  }
+}
+
+const fetchMessages = async queryStringOptions => {
+  const queryString = new URLSearchParams(queryStringOptions).toString()
+  const response = await fetch(`/drift-radiator/queue/${componentName}/${queryString}`)
+
+  if (!response.ok) {
+    throw new Error('There was a problem fetching the component data')
+  }
+
+  try {
+    const streamJson = await response.json()
+
+    streamJson.forEach(stream => {
+      const streamName = stream.name.split(':')
+      const streamType = streamName[0].charAt(0)
+      const streamKey = `${streamType}:${streamName[2]}`
+      const env = streamName[2]
+
+      const lastMessage = stream.messages[stream.messages.length - 1]
+      if (lastIds[streamKey]) {
+        lastIds[streamKey] = lastMessage.id
+      }
+
+      const version = lastMessage.message.v
+      const [date, build, sha] = version.split('.')
+      updateVersion({ env, version, date, build, sha })
+    })
+  } catch (e) {
+    console.error(e)
+  }
+}
+
+const watch = async () => {
+  await fetchMessages(lastIds)
+  setTimeout(watch, 10000)
+}
+
+jQuery(function () {
+  watch()
+})

--- a/assets/scss/local.scss
+++ b/assets/scss/local.scss
@@ -53,12 +53,18 @@
   clear: none;
 }
 
-.drift-tile {
-  width: 30%;
-  height: 6em;
-  display: inline-block;
-  background-color: lightgray;
-  padding: 10px
+.radiator-row {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  padding: 10px;
+}
+
+.radiator-tile {
+   flex: 0 0 320px;
+   margin: 1em;
+   padding: 10px;
+   background-color: lightgray;
 }
 
 .componentData {

--- a/assets/scss/local.scss
+++ b/assets/scss/local.scss
@@ -58,13 +58,17 @@
   flex-wrap: wrap;
   justify-content: center;
   padding: 10px;
-}
 
-.radiator-tile {
-   flex: 0 0 320px;
-   margin: 1em;
-   padding: 10px;
-   background-color: lightgray;
+  .radiator-tile {
+    flex: 0 0 320px;
+    margin: 1em;
+    padding: 10px;
+    background-color: lightgray;
+ 
+    .tile-value {
+       float: right;
+    }
+ }
 }
 
 .componentData {

--- a/assets/scss/local.scss
+++ b/assets/scss/local.scss
@@ -53,6 +53,14 @@
   clear: none;
 }
 
+.drift-tile {
+  width: 30%;
+  height: 6em;
+  display: inline-block;
+  background-color: lightgray;
+  padding: 10px
+}
+
 .componentData {
   th, td {
     padding: govuk-spacing(1);

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "compile-sass": "sass --quiet-deps --no-source-map --load-path=node_modules/govuk-frontend --load-path=node_modules/@ministryofjustice/frontend --load-path=. assets/scss/application.scss:./assets/stylesheets/application.css assets/scss/application-ie8.scss:./assets/stylesheets/application-ie8.css --style compressed",
     "watch-ts": "tsc -w",
     "watch-views": "nodemon --watch server/views -e html,njk -x npm run copy-views",
-    "watch-node": "DEBUG=gov-starter-server* nodemon -r dotenv/config --watch dist/ dist/server.js | bunyan -o short",
+    "watch-node": "DEBUG=gov-starter-server* nodemon -r dotenv/config --watch dist/ --watch assets/js dist/server.js | bunyan -o short",
     "watch-sass": "npm run compile-sass -- --watch",
     "build": "npm run compile-sass && tsc && npm run copy-views",
     "start": "node $NODE_OPTIONS dist/server.js | bunyan -o short",

--- a/server/app.ts
+++ b/server/app.ts
@@ -21,6 +21,7 @@ import productSetRoutes from './routes/productSets'
 import serviceAreaRoutes from './routes/serviceAreas'
 import monitorRoutes from './routes/monitor'
 import dependencyRoutes from './routes/dependencies'
+import driftRadiatorRoutes from './routes/driftRadiator'
 
 import type { Services } from './services'
 
@@ -48,6 +49,7 @@ export default function createApp(services: Services): express.Application {
   app.use('/service-areas', serviceAreaRoutes(services))
   app.use('/monitor', monitorRoutes(services))
   app.use('/dependencies', dependencyRoutes(services))
+  app.use('/drift-radiator', driftRadiatorRoutes(services))
 
   app.use((req, res, next) => next(createError(404, 'Not found')))
   app.use(errorHandler(process.env.NODE_ENV === 'production'))

--- a/server/routes/driftRadiator.ts
+++ b/server/routes/driftRadiator.ts
@@ -1,0 +1,54 @@
+import { type RequestHandler, Router } from 'express'
+import asyncMiddleware from '../middleware/asyncMiddleware'
+import type { Services } from '../services'
+import logger from '../../logger'
+import { getComponentName } from '../utils/utils'
+
+export default function routes({ serviceCatalogueService, redisService }: Services): Router {
+  const router = Router()
+
+  const get = (path: string, handler: RequestHandler) => router.get(path, asyncMiddleware(handler))
+
+  get('/', async (req, res) => {
+    return res.render('pages/components')
+  })
+
+  get('/data', async (req, res) => {
+    const components = await serviceCatalogueService.getComponents()
+
+    return res.send(components)
+  })
+
+  get('/:componentName', async (req, res) => {
+    const componentName = getComponentName(req)
+
+    const component = await serviceCatalogueService.getComponent(componentName)
+
+    const displayComponent = {
+      name: componentName,
+      api: component.api,
+      environments: component.environments,
+    }
+
+    return res.render('pages/driftRadiator', { component: displayComponent })
+  })
+
+  get('/queue/:componentName/*', async (req, res) => {
+    const componentName = getComponentName(req)
+    const queueInformation = req.params[0]
+
+    logger.info(`Queue call for ${componentName} with ${queueInformation}`)
+
+    const component = await serviceCatalogueService.getComponent(componentName)
+
+    const streams = component.environments
+      .map(e => `version:${component.name}:${e.name}`)
+      .map((key, id) => ({ key, id: `${id}` }))
+
+    const messages = await redisService.readStream(streams)
+
+    return res.send(messages)
+  })
+
+  return router
+}

--- a/server/views/pages/driftRadiator.njk
+++ b/server/views/pages/driftRadiator.njk
@@ -1,0 +1,45 @@
+{% extends "../partials/layout.njk" %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/panel/macro.njk" import govukPanel %}
+
+{% set pageTitle = applicationName + " - " + component.name %}
+{% set mainClasses = "app-container govuk-body" %}
+{% set devEnvName = component.environments[0].name %}
+
+{% block content %}
+
+{{ govukBackLink({
+  text: "Back",
+  href: "/components/" + component.name
+}) }}
+
+<h1 id="detailPageTitle">Deployment Drift Radiator</h1>  
+<h2>{{ component.name }}</h2>  
+    <p><a class="govuk-link--no-visited-state" href="https://app.circleci.com/pipelines/github/ministryofjustice/{{ component.name}}?branch=main">Circle CI pipeline</a></p>
+    
+    {% for environment in component.environments %}
+    <div class="drift-tile">
+      <strong>Environment:</strong> {{environment.name}}<br/>
+      <strong>Date:</strong> <span id="{{environment.name}}_date"></span><br/>
+      <strong>Build:</strong> <span id="{{environment.name}}_build"></span><br/> 
+      {% if environment.name != devEnvName %} 
+        <p id="{{ environment.name}}_details"></p>
+      {% endif %}
+    </div>
+    {% endfor %}
+{% endblock %}
+
+{% block bodyEnd %}
+  <script src="/assets/govuk/all.js"></script>
+  <script src="/assets/govukFrontendInit.js"></script>
+  <script src="/assets/moj/all.js"></script>
+  <script src="https://www.gstatic.com/charts/loader.js"></script>
+  <script nonce="{{ cspNonce }}">
+    const environments = ["{{ component.environments | join("\", \"", "name") | safe }}"]
+    const devEnvName = '{{ devEnvName }}'
+    const componentName = '{{ component.name }}'
+  </script>
+  <script src="/assets/js/dayjs/dayjs.min.js"></script>
+  <script src="/assets/js/dayjs/plugin/relativeTime.js"></script>
+  <script src="/assets/js/driftRadiator.js"></script>
+{% endblock %}

--- a/server/views/pages/driftRadiator.njk
+++ b/server/views/pages/driftRadiator.njk
@@ -17,16 +17,16 @@
 <h2>{{ component.name }}</h2>  
     <p><a class="govuk-link--no-visited-state" href="https://app.circleci.com/pipelines/github/ministryofjustice/{{ component.name}}?branch=main">Circle CI pipeline</a></p>
     
-    {% for environment in component.environments %}
-    <div class="drift-tile">
-      <strong>Environment:</strong> {{environment.name}}<br/>
-      <strong>Date:</strong> <span id="{{environment.name}}_date"></span><br/>
-      <strong>Build:</strong> <span id="{{environment.name}}_build"></span><br/> 
-      {% if environment.name != devEnvName %} 
-        <p id="{{ environment.name}}_details"></p>
-      {% endif %}
+    <div class="radiator-row">
+      {% for environment in component.environments %}
+      <div class="radiator-tile">
+        <strong>Environment:</strong> {{environment.name}}<br/>
+        <strong>Date:</strong> <span id="{{environment.name}}_date"></span><br/>
+        <strong>Build:</strong> <span id="{{environment.name}}_build"></span><br/> 
+        <span id="{{ environment.name}}_details"></span>
+      </div>
+      {% endfor %}
     </div>
-    {% endfor %}
 {% endblock %}
 
 {% block bodyEnd %}

--- a/server/views/pages/driftRadiator.njk
+++ b/server/views/pages/driftRadiator.njk
@@ -19,12 +19,7 @@
     
     <div class="radiator-row">
       {% for environment in component.environments %}
-      <div class="radiator-tile">
-        <strong>Environment:</strong> {{environment.name}}<br/>
-        <strong>Date:</strong> <span id="{{environment.name}}_date"></span><br/>
-        <strong>Build:</strong> <span id="{{environment.name}}_build"></span><br/> 
-        <span id="{{ environment.name}}_details"></span>
-      </div>
+        <div id="{{ environment.name}}_details" class="radiator-tile"></div>
       {% endfor %}
     </div>
 {% endblock %}


### PR DESCRIPTION
This is a bit of a WiP

If there is no drift: 
<kbd>
<img width="1218" alt="Screenshot 2023-11-22 at 09 20 04" src="https://github.com/ministryofjustice/hmpps-developer-portal/assets/1517745/2ec753c5-af70-4eba-917a-ba8e43a88922">
</kbd>

If there is a drift between environments:
<kbd>
<img width="1206" alt="Screenshot 2023-11-22 at 09 19 56" src="https://github.com/ministryofjustice/hmpps-developer-portal/assets/1517745/817e137b-dd05-4f5f-a792-e122cef6c99b">
</kbd>

Still need to:
* Consider showing multiple radiators for service area / product / team
* Add colours
* Add to table/search?
* etc...