### PR TITLE
Add support for additional health statuses

### DIFF
--- a/assets/js/monitor.js
+++ b/assets/js/monitor.js
@@ -147,7 +147,7 @@ const fetchMessages = async () => {
         $(`${tileName} .statusTileStatus`).text(healthStatus)
         $(tileName).removeClass('statusTileUp statusTileDown')
 
-        const statusClass = healthStatus === 'UP' ? 'statusTileUp' : 'statusTileDown'
+        const statusClass = ['UP', 'GREEN', 'SERVING'].includes(healthStatus.toUpperCase()) ? 'statusTileUp' : 'statusTileDown'
         $(tileName).addClass(statusClass)
         $(tileName).attr('data-status', healthStatus)
       }


### PR DESCRIPTION
Some non-Spring products use a different value to indicate the service is healthy e.g. Logstash uses "green", and Flipt uses "SERVING".

See https://developer-portal.hmpps.service.justice.gov.uk/monitor/product/probation-integration-services