### PR TITLE
HEAT-490 no template option

### DIFF
--- a/server/routes/componentRequests.ts
+++ b/server/routes/componentRequests.ts
@@ -242,7 +242,7 @@ const buildFormData = (formData: Record<string, unknown>): GithubRepoRequestRequ
     data: {
       github_repo: sanitiseString(formData.github_repo?.toString()),
       repo_description: sanitiseString(formData.repo_description?.toString()),
-      base_template: sanitiseString(formData.base_template?.toString()),
+      base_template: sanitiseString(formData.base_template?.toString().replace('none', '')),
       ...(formData.jira_project_keys
         ? { jira_project_keys: sanitiseString(formData.jira_project_keys.toString()).split(',') }
         : {}),

--- a/server/views/pages/componentRequestForm.njk
+++ b/server/views/pages/componentRequestForm.njk
@@ -63,7 +63,7 @@
             text: "hmpps-template-typescript"
           },
           {
-            value: none",
+            value: "none",
             text: "No template (create from scratch)"
           }]
       }) }}

--- a/server/views/pages/componentRequestForm.njk
+++ b/server/views/pages/componentRequestForm.njk
@@ -63,8 +63,8 @@
             text: "hmpps-template-typescript"
           },
           {
-            value: "github-only",
-            text: "github-only"
+            value: none",
+            text: "No template (create from scratch)"
           }]
       }) }}
       {{ govukSelect({


### PR DESCRIPTION
Slightly modified caption for 'no template' option (since github-only doesn't really fit the criteria) and then some necessary parsing of the output to ensure one of the options is selected while also sending a blank entry to the request components table in Service Catalogue.

Validated with a project in dev.