### PR TITLE
Fix componentFormRequest email validation

### DIFF
--- a/server/routes/componentRequests.ts
+++ b/server/routes/componentRequests.ts
@@ -193,10 +193,13 @@ export default function routes({ componentNameService, serviceCatalogueService, 
         })
       } else {
         const requesterEmail = body.requester_email?.toString()
-        if (!requesterEmail.endsWith('@digital.justice.gov.uk')) {
+        if (
+          !requesterEmail.endsWith('@digital.justice.gov.uk') &&
+          !requesterEmail.endsWith('@justice.gov.uk')
+        ) {
           validationErrors.push({
             field: 'requesterEmail',
-            message: 'Valid email address is only with @digital.justice.gov.uk',
+            message: 'Valid email address is only with @digital.justice.gov.uk or @justice.gov.uk',
             href: '#requester_email',
           })
         }

--- a/server/routes/componentRequests.ts
+++ b/server/routes/componentRequests.ts
@@ -193,10 +193,7 @@ export default function routes({ componentNameService, serviceCatalogueService, 
         })
       } else {
         const requesterEmail = body.requester_email?.toString()
-        if (
-          !requesterEmail.endsWith('@digital.justice.gov.uk') &&
-          !requesterEmail.endsWith('@justice.gov.uk')
-        ) {
+        if (!requesterEmail.endsWith('@digital.justice.gov.uk') && !requesterEmail.endsWith('@justice.gov.uk')) {
           validationErrors.push({
             field: 'requesterEmail',
             message: 'Valid email address is only with @digital.justice.gov.uk or @justice.gov.uk',


### PR DESCRIPTION
Form description says that `@digital.justice.gov.uk` and `@justice.gov.uk` email's are valid, then complains saying you can only use a `@digital.justice.gov.uk` email. Considering these are going away, thought it was worth fixing!