### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/security_veracode_policy_scan.yml
+++ b/.github/workflows/security_veracode_policy_scan.yml
@@ -1,5 +1,8 @@
 name: Security veracode policy scan
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/ministryofjustice/hmpps-developer-portal/security/code-scanning/4](https://github.com/ministryofjustice/hmpps-developer-portal/security/code-scanning/4)

To fix the issue, add a `permissions` block at the root level of the workflow to explicitly define the least privileges required. Since the workflow appears to perform a security scan and send alerts to a Slack channel, it likely only needs `contents: read` permissions. This ensures that the `GITHUB_TOKEN` cannot perform unintended actions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
