### PR TITLE
Tidying up github request type

### DIFF
--- a/assets/js/componentRequests.js
+++ b/assets/js/componentRequests.js
@@ -1,31 +1,23 @@
 jQuery(function () {
   const columns = [
     {
-      data: 'attributes.github_repo',
+      data: 'github_repo',
       createdCell: function (td, _cellData, rowData) {
-        $(td).html(
-          `<a href="/component-requests/${rowData.attributes.github_repo}">${rowData.attributes.github_repo}</a>`,
-        )
+        $(td).html(`<a href="/component-requests/${rowData.github_repo}">${rowData.github_repo}</a>`)
       },
     },
     {
-      data: 'attributes.requester_name',
-      createdCell: function (td, _cellData, rowData) {
-        $(td).html(`${rowData.attributes.requester_name}`)
-      },
+      data: 'requester_name',
     },
     {
-      data: 'attributes.request_github_pr_status',
-      createdCell: function (td, _cellData, rowData) {
-        $(td).html(`${rowData.attributes.request_github_pr_status}`)
-      },
+      data: 'request_github_pr_status',
     },
     {
-      data: 'attributes.request_github_pr_number',
+      data: 'request_github_pr_number',
       createdCell: function (td, _cellData, rowData) {
-        if (rowData.attributes.request_github_pr_number) {
+        if (rowData.request_github_pr_number) {
           $(td).html(
-            `<a href="https://github.com/ministryofjustice/hmpps-project-bootstrap/pull/${rowData.attributes.request_github_pr_number}">${rowData.attributes.request_github_pr_number}</a>`,
+            `<a href="https://github.com/ministryofjustice/hmpps-project-bootstrap/pull/${rowData.request_github_pr_number}">${rowData.request_github_pr_number}</a>`,
           )
         } else {
           $(td).html('')

--- a/server/data/converters/trivyScans.ts
+++ b/server/data/converters/trivyScans.ts
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 import { DataItem, TrivyScan } from '../strapiApiTypes'
-import type { TrivyScanType } from './modelTypes'
+import type { ScanSummary, TrivyScanType } from './modelTypes'
 
 const convertTrivyScan = (trivyScan: DataItem<TrivyScan>): TrivyScanType => {
   const { attributes, id } = trivyScan

--- a/server/data/restClient.ts
+++ b/server/data/restClient.ts
@@ -72,13 +72,13 @@ export default class RestClient {
     }
   }
 
-  async post({
+  async post<T>({
     path = null,
     headers = {},
     responseType = '',
     data = {},
     raw = false,
-  }: PostRequest = {}): Promise<unknown> {
+  }: PostRequest = {}): Promise<T> {
     logger.info(`Post calling ${this.name}: ${path}`)
     try {
       const result = await superagent
@@ -94,7 +94,7 @@ export default class RestClient {
         .responseType(responseType)
         .timeout(this.timeoutConfig())
 
-      return raw ? result : result.body
+      return raw ? (result as T) : result.body
     } catch (error) {
       const sanitisedError = sanitiseError(error)
       logger.warn({ ...sanitisedError }, `Error calling ${this.name}, path: '${path}', verb: 'POST'`)

--- a/server/data/strapiApiClient.test.ts
+++ b/server/data/strapiApiClient.test.ts
@@ -211,7 +211,7 @@ describe('strapiApiClient', () => {
       } as GithubRepoRequestRequest
       fakeStrapiApi.post('/github-repo-requests').reply(200, response)
 
-      const output = await strapiApiClient.postGithubRepoRequest({
+      await strapiApiClient.postGithubRepoRequest({
         data: {
           github_repo: 'Test01',
           repo_description: 'Test Data',
@@ -228,8 +228,6 @@ describe('strapiApiClient', () => {
           nonprod_alerts_severity_label: 'hmpps-sre-nonprod-slack-channel',
         },
       })
-
-      expect(output).toEqual(response)
     })
   })
 

--- a/server/data/strapiApiClient.ts
+++ b/server/data/strapiApiClient.ts
@@ -17,6 +17,7 @@ import {
   TrivyScan,
   Environment,
   SingleResponse,
+  DataItem,
 } from './strapiApiTypes'
 import { convertServiceArea } from './converters/serviceArea'
 import type { ServiceArea, TrivyScanType } from './converters/modelTypes'
@@ -242,22 +243,26 @@ export default class StrapiApiClient {
     })
   }
 
-  async getGithubRepoRequests(): Promise<ListResponse<GithubRepoRequest>> {
-    return this.restClient.get({
-      path: '/v1/github-repo-requests',
-      query: 'populate=github_repo',
-    })
+  async getGithubRepoRequests(): Promise<Array<GithubRepoRequest>> {
+    return this.restClient
+      .get<ListResponse<GithubRepoRequest>>({
+        path: '/v1/github-repo-requests',
+        query: 'populate=github_repo',
+      })
+      .then(this.unwrapListResponse)
   }
 
-  async getGithubRepoRequest({ repoName }: { repoName: string }): Promise<SingleResponse<GithubRepoRequest>> {
-    return this.restClient.get({
-      path: '/v1/github-repo-requests',
-      query: `filters[github_repo][$eq]=${repoName}`,
-    })
+  async getGithubRepoRequest({ repoName }: { repoName: string }): Promise<GithubRepoRequest> {
+    return this.restClient
+      .get<SingleResponse<GithubRepoRequest>>({
+        path: '/v1/github-repo-requests',
+        query: `filters[github_repo][$eq]=${repoName}`,
+      })
+      .then(this.unwrapSingleResponse)
   }
 
-  async postGithubRepoRequest(request: GithubRepoRequestRequest): Promise<SingleResponse<GithubRepoRequest>> {
-    return this.restClient.post({
+  async postGithubRepoRequest(request: GithubRepoRequestRequest): Promise<void> {
+    await this.restClient.post<SingleResponse<GithubRepoRequest>>({
       path: '/v1/github-repo-requests',
       data: request,
     })
@@ -308,5 +313,15 @@ export default class StrapiApiClient {
       path: '/v1/environments',
       query: 'populate=component',
     })
+  }
+
+  private unwrapSingleResponse<T>(response: SingleResponse<T>): T & { id: number } {
+    const data =
+      Array.isArray(response.data) && response.data.length > 0 ? (response.data[0] as DataItem<T>) : response.data
+    return { ...data.attributes, id: data.id }
+  }
+
+  private unwrapListResponse<T>(response: ListResponse<T>): Array<T & { id: number }> {
+    return response.data.map(({ id, attributes }) => ({ ...attributes, id }))
   }
 }

--- a/server/routes/componentRequests.ts
+++ b/server/routes/componentRequests.ts
@@ -36,29 +36,7 @@ export default function routes({ componentNameService, serviceCatalogueService, 
   get('/:repo_name', async (req, res) => {
     const repoName = req.params.repo_name
     const componentRequest = await serviceCatalogueService.getGithubRepoRequest({ repoName })
-    const displayComponent = {
-      github_repo: componentRequest.github_repo,
-      repo_description: componentRequest.repo_description,
-      base_template: componentRequest.base_template,
-      jira_project_keys: componentRequest.jira_project_keys,
-      github_project_visibility: componentRequest.github_project_visibility,
-      product: componentRequest.product,
-      slack_channel_prod_release_notify: componentRequest.slack_channel_prod_release_notify,
-      slack_channel_nonprod_release_notify: componentRequest.slack_channel_nonprod_release_notify,
-      slack_channel_security_scans_notify: componentRequest.slack_channel_security_scans_notify,
-      prod_alerts_severity_label: componentRequest.prod_alerts_severity_label,
-      nonprod_alerts_severity_label: componentRequest.nonprod_alerts_severity_label,
-      github_project_teams_write: componentRequest.github_project_teams_write,
-      github_projects_teams_admin: componentRequest.github_projects_teams_admin,
-      github_project_branch_protection_restricted_teams:
-        componentRequest.github_project_branch_protection_restricted_teams,
-      requester_name: componentRequest.requester_name,
-      requester_email: componentRequest.requester_email,
-      requester_team: componentRequest.requester_team,
-      request_github_pr_status: componentRequest.request_github_pr_status,
-      request_github_pr_number: componentRequest.request_github_pr_number,
-    }
-    return res.render('pages/componentRequest', { componentRequest: displayComponent })
+    return res.render('pages/componentRequest', { componentRequest })
   })
 
   post('/new', async (req, res): Promise<void> => {

--- a/server/services/componentNameService.test.ts
+++ b/server/services/componentNameService.test.ts
@@ -219,13 +219,11 @@ describe('Component name service', () => {
   })
 
   describe('checkComponentRequestExists()', () => {
-    const testComponentsResponse = {
-      data: [
-        { attributes: { github_repo: 'comp-3' } },
-        { attributes: { github_repo: 'comp-1' } },
-        { attributes: { github_repo: 'comp-2' } },
-      ],
-    } as ListResponse<GithubRepoRequest>
+    const testComponentsResponse = [
+      { github_repo: 'comp-3' },
+      { github_repo: 'comp-1' },
+      { github_repo: 'comp-2' },
+    ] as GithubRepoRequest[]
 
     it('should return true if component exists', async () => {
       strapiApiClient.getGithubRepoRequests.mockResolvedValue(testComponentsResponse)

--- a/server/services/componentNameService.ts
+++ b/server/services/componentNameService.ts
@@ -99,9 +99,7 @@ export default class ComponentNameService {
 
   async checkComponentRequestExists(repositoryName: string): Promise<boolean> {
     const componentData = await this.strapiApiClientFactory('').getGithubRepoRequests()
-    const components = componentData.data.find(
-      repoName => formatMonitorName(repoName.attributes.github_repo) === repositoryName,
-    )
+    const components = componentData.find(repoName => formatMonitorName(repoName.github_repo) === repositoryName)
     return !!components
   }
 }

--- a/server/services/serviceCatalogueService.test.ts
+++ b/server/services/serviceCatalogueService.test.ts
@@ -518,49 +518,38 @@ describe('Strapi service', () => {
 
   describe('Repo Requests', () => {
     describe('getGithubRepoRequests', () => {
-      const testGithubRepoRequestsResponse = {
-        data: [
-          {
-            id: 1,
-            attributes: { github_repo: 'github_repo-1' },
-          },
-          {
-            id: 2,
-            attributes: { github_repo: 'github_repo-2' },
-          },
-        ],
-      } as ListResponse<GithubRepoRequest>
-      const testGithubRepoRequests = [
-        { id: 1, attributes: { github_repo: 'github_repo-1' } },
-        { id: 2, attributes: { github_repo: 'github_repo-2' } },
-      ] as DataItem<GithubRepoRequest>[]
+      const githubResponses = [
+        {
+          github_repo: 'github_repo-1',
+        },
+        {
+          github_repo: 'github_repo-2',
+        },
+      ] as GithubRepoRequest[]
 
       it('should return an ordered array of repo requests', async () => {
-        strapiApiClient.getGithubRepoRequests.mockResolvedValue(testGithubRepoRequestsResponse)
+        strapiApiClient.getGithubRepoRequests.mockResolvedValue(githubResponses)
 
         const results = await serviceCatalogueService.getGithubRepoRequests()
 
         expect(strapiApiClient.getGithubRepoRequests).toHaveBeenCalledTimes(1)
-        expect(results).toEqual(testGithubRepoRequests)
+        expect(results).toEqual(githubResponses)
       })
     })
 
     describe('getGithubRepoRequest', () => {
-      const testGithubRepoRequestResponse = {
-        data: {
-          id: 1,
-          attributes: { name: 'github_repo-1' },
-        },
-      } as SingleResponse<GithubRepoRequest>
-      const testGithubRepoRequest = { name: 'github_repo-1' } as GithubRepoRequest
+      const githubRequestResponse = {
+        id: 1,
+        name: 'github_repo-1',
+      } as GithubRepoRequest & { id: number }
 
       it('should return the selected repo request', async () => {
-        strapiApiClient.getGithubRepoRequest.mockResolvedValue(testGithubRepoRequestResponse)
+        strapiApiClient.getGithubRepoRequest.mockResolvedValue(githubRequestResponse)
 
         const results = await serviceCatalogueService.getGithubRepoRequest({ repoName: 'github_repo-1' })
 
         expect(strapiApiClient.getGithubRepoRequest).toHaveBeenCalledTimes(1)
-        expect(results).toEqual(testGithubRepoRequest)
+        expect(results).toEqual(githubRequestResponse)
       })
     })
   })

--- a/server/services/serviceCatalogueService.ts
+++ b/server/services/serviceCatalogueService.ts
@@ -15,7 +15,6 @@ import {
   ScheduledJob,
   DataItem,
   Environment,
-  SingleResponse,
 } from '../data/strapiApiTypes'
 import { sortData, sortRdsInstances, sortComponentRequestData, sortGithubTeamsData, sortByName } from '../utils/utils'
 
@@ -284,29 +283,20 @@ export default class ServiceCatalogueService {
     return customComponentView
   }
 
-  async getGithubRepoRequests(): Promise<DataItem<GithubRepoRequest>[]> {
+  async getGithubRepoRequests(): Promise<GithubRepoRequest[]> {
     const strapiApiClient = this.strapiApiClientFactory('')
     const componentRequestsData = await strapiApiClient.getGithubRepoRequests()
-    const componentRequests = componentRequestsData.data.sort(sortComponentRequestData)
-
-    return componentRequests
+    return componentRequestsData.sort(sortComponentRequestData)
   }
 
   async getGithubRepoRequest({ repoName }: { repoName: string }): Promise<GithubRepoRequest> {
     const strapiApiClient = this.strapiApiClientFactory('')
-    const componentRequestData = await strapiApiClient.getGithubRepoRequest({ repoName })
-    const componentRequest =
-      Array.isArray(componentRequestData.data) && componentRequestData.data.length > 0
-        ? componentRequestData.data[0].attributes
-        : componentRequestData.data?.attributes
-    return componentRequest
+    return strapiApiClient.getGithubRepoRequest({ repoName })
   }
 
-  async postGithubRepoRequest(request: GithubRepoRequestRequest): Promise<SingleResponse<GithubRepoRequest>> {
+  async postGithubRepoRequest(request: GithubRepoRequestRequest): Promise<void> {
     const strapiApiClient = this.strapiApiClientFactory('')
-    const response = await strapiApiClient.postGithubRepoRequest(request)
-
-    return response
+    return strapiApiClient.postGithubRepoRequest(request)
   }
 
   async getEnvironments(): Promise<DataItem<Environment>[]> {

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -10,7 +10,7 @@ import { DataItem, Environment } from '../data/strapiApiTypes'
 dayjs.extend(relativeTime.default)
 
 type HasName = { attributes?: { name: string } }
-type HasRepoName = { attributes?: { github_repo: string } }
+type HasRepoName = { github_repo: string }
 type HasTeamName = { attributes?: { team_name: string } }
 
 const properCase = (word: string): string =>
@@ -97,7 +97,7 @@ export const sortRdsInstances = (rdsInstance: RdsEntry, compareRdsInstance: RdsE
 }
 
 export const sortComponentRequestData = (dataItem: HasRepoName, compareDataItem: HasRepoName) => {
-  return dataItem.attributes.github_repo.localeCompare(compareDataItem.attributes.github_repo)
+  return dataItem.github_repo.localeCompare(compareDataItem.github_repo)
 }
 
 export const sortGithubTeamsData = (dataItem: HasTeamName, compareDataItem: HasTeamName) => {


### PR DESCRIPTION
Example of moving to generically unwrap strapi wrappers in client to continue decoupling rest of the code from strapi