### PR TITLE
HEAT 1230 update helm dependencies notation type

### DIFF
--- a/server/services/dependencyComparison.ts
+++ b/server/services/dependencyComparison.ts
@@ -122,10 +122,10 @@ const classifyVersionStatus = (current?: string, recommended?: string): Dependen
 const getCurrentDependencyVersionsFromComponent = (component: Component) => {
   const versions = (component.versions || {}) as Record<string, unknown>
 
-  const helmDeps = (versions.helm_dependencies as Record<string, unknown>) || {}
-  const helmLegacy = (versions.helm as Record<string, unknown>) || {}
+  const helmDeps = (versions['Helm Dependencies'] as Record<string, unknown>) || {}
+  const helmLegacy = (versions.Helm as Record<string, unknown>) || {}
   const helmLegacyDeps = (helmLegacy.dependencies as Record<string, unknown>) || {}
-  const gradle = (versions.gradle as Record<string, unknown>) || {}
+  const gradle = (versions.Gradle as Record<string, unknown>) || {}
 
   const currentGenericPrometheusAlerts =
     parseVersionToString(helmDeps?.generic_prometheus_alerts) ||

--- a/server/services/recommendedVersionsService.test.ts
+++ b/server/services/recommendedVersionsService.test.ts
@@ -6,14 +6,14 @@ jest.mock('./serviceCatalogueService')
 // Minimal shape used by RecommendedVersionsService when reading from Strapi
 type strapiComponentMock = {
   versions?: {
-    helm_dependencies?: Record<string, unknown>
-    helm?: { dependencies?: Record<string, unknown> }
-    gradle?: { hmpps_gradle_spring_boot?: unknown }
+    ['Helm Dependencies']?: Record<string, unknown>
+    ['Helm']?: { dependencies?: Record<string, unknown> }
+    ['Gradle']?: { hmpps_gradle_spring_boot?: unknown }
   }
   values?: {
-    helm_dependencies?: Record<string, unknown>
-    helm?: { dependencies?: Record<string, unknown> }
-    gradle?: { hmpps_gradle_spring_boot?: unknown }
+    ['Helm Dependencies']?: Record<string, unknown>
+    ['Helm']?: { dependencies?: Record<string, unknown> }
+    ['Gradle']?: { hmpps_gradle_spring_boot?: unknown }
   }
 }
 
@@ -35,11 +35,11 @@ describe('RecommendedVersionsService (Strapi only)', () => {
   it('returns versions from Strapi component (preferred keys)', async () => {
     const component = {
       versions: {
-        helm_dependencies: {
+        'Helm Dependencies': {
           generic_prometheus_alerts: { ref: '1.2.3' },
           generic_service: { ref: '4.5.6' },
         },
-        gradle: {
+        Gradle: {
           hmpps_gradle_spring_boot: { ref: '7.8.9' },
         },
       },
@@ -55,13 +55,13 @@ describe('RecommendedVersionsService (Strapi only)', () => {
   it('supports legacy helm dependencies shape', async () => {
     const component = {
       versions: {
-        helm: {
+        Helm: {
           dependencies: {
             'generic-prometheus-alerts': '2.3.4',
             'generic-service': '5.6.7',
           },
         },
-        gradle: {
+        Gradle: {
           hmpps_gradle_spring_boot: '8.9.10',
         },
       },
@@ -87,11 +87,11 @@ describe('RecommendedVersionsService (Strapi only)', () => {
   it('caches results for TTL duration', async () => {
     const component = {
       versions: {
-        helm_dependencies: {
+        'Helm Dependencies': {
           generic_prometheus_alerts: { ref: '9.9.9' },
           generic_service: { ref: '9.9.8' },
         },
-        gradle: {
+        Gradle: {
           hmpps_gradle_spring_boot: { ref: '9.9.7' },
         },
       },

--- a/server/services/recommendedVersionsService.ts
+++ b/server/services/recommendedVersionsService.ts
@@ -171,7 +171,7 @@ export default class RecommendedVersionsService {
       const values = ((component as ComponentWithValues).values || {}) as Record<string, unknown>
 
       // Preferred keys from versions
-      const helmDeps = (versions.helm_dependencies as Record<string, unknown>) || {}
+      const helmDeps = (versions['Helm Dependencies'] as Record<string, unknown>) || {}
       let helmGenericPrometheusAlerts = this.parseVersionValue(helmDeps?.generic_prometheus_alerts)
       let helmGenericService = this.parseVersionValue(helmDeps?.generic_service)
       // Fallback to hyphenated keys directly under helm_dependencies
@@ -182,12 +182,12 @@ export default class RecommendedVersionsService {
         helmGenericService = this.parseVersionValue(helmDeps['generic-service'])
       }
       let gradleHmppsGradleSpringBoot = this.parseVersionValue(
-        (versions.gradle as Record<string, unknown>)?.hmpps_gradle_spring_boot,
+        (versions.Gradle as Record<string, unknown>)?.hmpps_gradle_spring_boot,
       )
 
       // Legacy helm shape in versions
       if (!helmGenericPrometheusAlerts || !helmGenericService) {
-        const helm = versions.helm as Record<string, unknown>
+        const helm = versions.Helm as Record<string, unknown>
         const deps = (helm?.dependencies as Record<string, unknown>) || {}
         helmGenericPrometheusAlerts =
           helmGenericPrometheusAlerts || this.parseVersionValue(deps['generic-prometheus-alerts'])


### PR DESCRIPTION
- changed from dot notation to bracket notation for helm dependencies, helm and gradle. Updated tests.