### PR TITLE
refactor: Remove npm from final image using new alpine-runtime image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
-# Stage: base image
-FROM ghcr.io/ministryofjustice/hmpps-node:24-alpine AS base
+# Build args available to all stages
+ARG BUILD_NUMBER
+ARG GIT_REF
+ARG GIT_BRANCH
 
-LABEL maintainer="HMPPS Digital Studio <info@digital.justice.gov.uk>"
+# Stage: build assets
+FROM ghcr.io/ministryofjustice/hmpps-node:24-alpine AS build
 
 ARG BUILD_NUMBER
 ARG GIT_REF
@@ -11,18 +14,6 @@ ARG GIT_BRANCH
 RUN test -n "$BUILD_NUMBER" || (echo "BUILD_NUMBER not set" && false)
 RUN test -n "$GIT_REF" || (echo "GIT_REF not set" && false)
 RUN test -n "$GIT_BRANCH" || (echo "GIT_BRANCH not set" && false)
-
-# Define env variables for runtime health / info
-ENV BUILD_NUMBER=${BUILD_NUMBER}
-ENV GIT_REF=${GIT_REF}
-ENV GIT_BRANCH=${GIT_BRANCH}
-
-# Stage: build assets
-FROM base AS build
-
-ARG BUILD_NUMBER
-ARG GIT_REF
-ARG GIT_BRANCH
 
 COPY package*.json .allowed-scripts.mjs .npmrc ./
 RUN CYPRESS_INSTALL_BINARY=0 npm run setup --no-audit
@@ -34,7 +25,13 @@ RUN npm run build
 RUN npm prune --no-audit --omit=dev
 
 # Stage: copy production assets and dependencies
-FROM base
+FROM ghcr.io/ministryofjustice/hmpps-node:24-alpine-runtime
+
+LABEL maintainer="HMPPS Digital Studio <info@digital.justice.gov.uk>"
+
+ARG BUILD_NUMBER
+ARG GIT_REF
+ARG GIT_BRANCH
 
 COPY --from=build --chown=appuser:appgroup \
         /app/package.json \
@@ -51,7 +48,10 @@ COPY --from=build --chown=appuser:appgroup \
         /app/node_modules ./node_modules
 
 EXPOSE 3000
+ENV BUILD_NUMBER=${BUILD_NUMBER}
+ENV GIT_REF=${GIT_REF}
+ENV GIT_BRANCH=${GIT_BRANCH}
 ENV NODE_ENV='production'
 USER 2000
 
-CMD [ "npm", "start" ]
+CMD [ "node", "dist/server.js" ]


### PR DESCRIPTION
Consolidate to 2-stage build with alpine-runtime final stage, eliminating npm and reducing attack surface.
