### PR TITLE
Rename vulnerability SLAs to overdue vulnerabilities and improve sorting

### DIFF
--- a/assets/js/dependencies.js
+++ b/assets/js/dependencies.js
@@ -1,6 +1,6 @@
 jQuery(function () {
   $('#selectDependency').on('click', async e => {
-    e.preventDefault(e)
+    e.preventDefault()
 
     const typeSelect = document.getElementById('dependencyType')
     const nameSelect = document.getElementById('dependencyName')

--- a/assets/js/monitor.js
+++ b/assets/js/monitor.js
@@ -103,7 +103,7 @@ jQuery(async function () {
   })
 
   $('#updateProduct,#updateTeam,#updateServiceArea,#updateCustomComponentView').on('click', async e => {
-    e.preventDefault(e)
+    e.preventDefault()
 
     let dropDownType = ''
 

--- a/assets/js/overdueVulnerabilities.js
+++ b/assets/js/overdueVulnerabilities.js
@@ -2,6 +2,6 @@ jQuery(async function () {
   $('#updateServiceArea').on('click', async e => {
     e.preventDefault(e)
     const serviceAreaSlug = document.getElementById('service-area').value
-    window.location = `/vulnerability-slas/${serviceAreaSlug}`
+    window.location = `/overdue-vulnerabilities/${serviceAreaSlug}`
   })
 })

--- a/assets/js/overdueVulnerabilitiesForProduct.js
+++ b/assets/js/overdueVulnerabilitiesForProduct.js
@@ -1,6 +1,6 @@
 jQuery(async function () {
   $('#updateServiceArea').on('click', async e => {
-    e.preventDefault(e)
+    e.preventDefault()
     const serviceAreaSlug = document.getElementById('service-area').value
     window.location = `/overdue-vulnerabilities/${serviceAreaSlug}`
   })

--- a/assets/js/overdueVulnerabilitiesForServiceArea.js
+++ b/assets/js/overdueVulnerabilitiesForServiceArea.js
@@ -1,0 +1,38 @@
+jQuery(async function () {
+  const serviceAreaSlug = document.getElementById('service-area').value
+  $('#updateServiceArea').on('click', async e => {
+    e.preventDefault()
+    const newAreaSlug = document.getElementById('service-area').value
+
+    window.location = `/overdue-vulnerabilities/${newAreaSlug}`
+  })
+
+  const columns = [
+    {
+      data: 'name',
+      createdCell: function (td, _cellData, rowData) {
+        $(td).html(
+          `<a href="/overdue-vulnerabilities/${serviceAreaSlug}/product/${rowData.slug}" class="govuk-link--no-visited-state">${rowData.name}</a>`,
+        )
+      },
+    },
+    {
+      data: 'numberOfBreachedComponents',
+    },
+    {
+      data: 'totalComponents',
+    },
+    {
+      data: 'numberOfBreachedVulnerabilities',
+    },
+  ]
+
+  createTable({
+    id: 'products',
+    ajaxUrl: `/overdue-vulnerabilities/${serviceAreaSlug}.json`,
+    orderColumn: 0,
+    orderType: 'asc',
+    columns,
+    pageLength: 25,
+  })
+})

--- a/assets/js/productDependencies.js
+++ b/assets/js/productDependencies.js
@@ -19,12 +19,12 @@ jQuery(async function () {
   graph.setAttribute('width', '100%')
 
   $('#updateProduct').on('click', async e => {
-    e.preventDefault(e)
+    e.preventDefault()
     const productCode = document.getElementById('product').value
     window.location = `/product-dependencies/${productCode}`
   })
   $('#toggleOrientation').on('click', async e => {
-    e.preventDefault(e)
+    e.preventDefault()
     const urlParams = new URLSearchParams(window.location.search)
     const orientation = urlParams.get('orientation') == 'LR' ? 'TB' : 'LR'
     const productCode = document.getElementById('product').value

--- a/assets/js/serviceAreaDiagram.js
+++ b/assets/js/serviceAreaDiagram.js
@@ -19,13 +19,13 @@ jQuery(async function () {
   graph.setAttribute('width', '100%')
 
   $('#updateServiceArea').on('click', async e => {
-    e.preventDefault(e)
+    e.preventDefault()
     const serviceAreaId = document.getElementById('serviceArea').value
     window.location = `/service-areas/${serviceAreaId}/diagram`
   })
 
   $('#toggleOrientation').on('click', async e => {
-    e.preventDefault(e)
+    e.preventDefault()
     const urlParams = new URLSearchParams(window.location.search)
     const orientation = urlParams.get('orientation') == 'TB' ? 'LR' : 'TB'
     const serviceAreaId = document.getElementById('serviceAreaSlug').value

--- a/assets/scss/application.scss
+++ b/assets/scss/application.scss
@@ -11,4 +11,4 @@ $govuk-page-width: $moj-page-width;
 @import 'assets/scss/local';
 @import 'assets/scss/alerts';
 @import 'assets/scss/teamOverview';
-@import 'assets/scss/vulnerabilitySlas';
+@import 'assets/scss/overdueVulnerabilities';

--- a/assets/scss/overdueVulnerabilities.scss
+++ b/assets/scss/overdueVulnerabilities.scss
@@ -1,0 +1,3 @@
+.update-service-area {
+  margin-top: 1.5em;
+}

--- a/assets/scss/vulnerabilitySlas.scss
+++ b/assets/scss/vulnerabilitySlas.scss
@@ -1,6 +1,0 @@
-.no-breaches {
-  color: govuk-colour('black', $variant: 'tint-50');
-}
-.update-service-area {
-  margin-top: 1.5em;
-}

--- a/server/app.ts
+++ b/server/app.ts
@@ -35,7 +35,7 @@ import githubTeamsRoutes from './routes/githubTeams'
 import scheduledJobsRoutes from './routes/scheduledJobs'
 import alertsRoutes from './routes/alerts'
 import snykScansRoutes from './routes/snykScans'
-import vulnerabilitySlasRoutes from './routes/vulnerabilitySlas'
+import overdueVulnerabilitiesRoutes from './routes/overdueVulnerabilities'
 
 import type { Services } from './services'
 
@@ -77,7 +77,7 @@ export default function createApp(services: Services): express.Application {
   app.use('/scheduled-jobs', scheduledJobsRoutes(services))
   app.use('/alerts', alertsRoutes(services))
   app.use('/snyk-scans', snykScansRoutes(services))
-  app.use('/vulnerability-slas', vulnerabilitySlasRoutes(services))
+  app.use('/overdue-vulnerabilities', overdueVulnerabilitiesRoutes(services))
 
   app.use((req, res, next) => next(createError(404, 'Not found')))
   app.use(errorHandler(process.env.NODE_ENV === 'production'))

--- a/server/routes/overdueVulnerabilities.ts
+++ b/server/routes/overdueVulnerabilities.ts
@@ -8,7 +8,7 @@ export default function routes({ serviceCatalogueService, cveSlaService }: Servi
   router.get('/', async (req, res) => {
     const serviceAreas = await serviceCatalogueService.getServiceAreas({ withComponents: false })
     assert(serviceAreas.length > 0, 'No service areas found in the service catalogue')
-    res.redirect(`overdue-vulnerabilities/${serviceAreas[0].slug}`)
+    res.redirect(`/overdue-vulnerabilities/${serviceAreas[0].slug}`)
   })
 
   router.get('/:serviceAreaSlug.json', async (req, res) => {

--- a/server/routes/overdueVulnerabilities.ts
+++ b/server/routes/overdueVulnerabilities.ts
@@ -8,7 +8,7 @@ export default function routes({ serviceCatalogueService, cveSlaService }: Servi
   router.get('/', async (req, res) => {
     const serviceAreas = await serviceCatalogueService.getServiceAreas({ withComponents: false })
     assert(serviceAreas.length > 0, 'No service areas found in the service catalogue')
-    res.redirect(`vulnerability-slas/${serviceAreas[0].slug}`)
+    res.redirect(`overdue-vulnerabilities/${serviceAreas[0].slug}`)
   })
 
   router.get('/:serviceAreaSlug.json', async (req, res) => {
@@ -21,7 +21,7 @@ export default function routes({ serviceCatalogueService, cveSlaService }: Servi
     const { serviceAreaSlug } = req.params
     const serviceAreas = await serviceCatalogueService.getServiceAreas({ withComponents: false })
     const serviceArea = await cveSlaService.getCveSlaForServiceArea(serviceAreaSlug)
-    res.render(`pages/vulnerabilitySlasForServiceArea`, {
+    res.render(`pages/overdueVulnerabilitiesForServiceArea`, {
       serviceArea,
       serviceAreas,
       selectedServiceArea: serviceAreaSlug,
@@ -32,7 +32,7 @@ export default function routes({ serviceCatalogueService, cveSlaService }: Servi
     const { serviceAreaSlug, productSlug } = req.params
     const serviceAreas = await serviceCatalogueService.getServiceAreas({ withComponents: false })
     const result = await cveSlaService.getCveSlaForProduct(serviceAreaSlug, productSlug)
-    res.render(`pages/vulnerabilitySlasForProduct`, {
+    res.render(`pages/overdueVulnerabilitiesForProduct`, {
       serviceArea: result.serviceArea,
       product: result.product,
       serviceAreas,

--- a/server/routes/overdueVulnerabilities.ts
+++ b/server/routes/overdueVulnerabilities.ts
@@ -14,16 +14,24 @@ export default function routes({ serviceCatalogueService, cveSlaService }: Servi
   router.get('/:serviceAreaSlug.json', async (req, res) => {
     const { serviceAreaSlug } = req.params
     const cves = await cveSlaService.getCveSlaForServiceArea(serviceAreaSlug)
-    res.json(cves)
+    res.json(
+      cves.productsWithComponents.map(product => ({
+        name: product.name,
+        slug: product.slug,
+        totalComponents: product.components.length,
+        numberOfBreachedComponents: product.numberOfBreachedComponents,
+        numberOfBreachedVulnerabilities: product.numberOfBreachedVulnerabilities,
+      })),
+    )
   })
 
   router.get('/:serviceAreaSlug', async (req, res) => {
     const { serviceAreaSlug } = req.params
     const serviceAreas = await serviceCatalogueService.getServiceAreas({ withComponents: false })
-    const serviceArea = await cveSlaService.getCveSlaForServiceArea(serviceAreaSlug)
+    const serviceAreaName = serviceAreas.find(sa => sa.slug === serviceAreaSlug)?.name
     res.render(`pages/overdueVulnerabilitiesForServiceArea`, {
-      serviceArea,
       serviceAreas,
+      serviceAreaName,
       selectedServiceArea: serviceAreaSlug,
     })
   })

--- a/server/routes/testutils/appSetup.ts
+++ b/server/routes/testutils/appSetup.ts
@@ -20,7 +20,7 @@ import namespacesRoutes from '../namespaces'
 import teamHealthRoutes from '../teamHealth'
 import githubTeamsRoutes from '../githubTeams'
 import snykScansRoutes from '../snykScans'
-import cveSlaRoutes from '../vulnerabilitySlas'
+import overdueVulnerabilitiesRoutes from '../overdueVulnerabilities'
 
 import nunjucksSetup from '../../utils/nunjucksSetup'
 import errorHandler from '../../errorHandler'
@@ -70,7 +70,7 @@ function appSetup(services: Services, production: boolean): Express {
   app.use('/team-health', teamHealthRoutes(services))
   app.use('/githubTeams', githubTeamsRoutes(services))
   app.use('/snyk-scans', snykScansRoutes(services))
-  app.use('/vulnerability-slas', cveSlaRoutes(services))
+  app.use('/overdue-vulnerabilities', overdueVulnerabilitiesRoutes(services))
 
   app.use((req, res, next) => next(createError(404, 'Not found')))
   app.use(errorHandler(production))

--- a/server/routes/vulnerabilitySlas.test.ts
+++ b/server/routes/vulnerabilitySlas.test.ts
@@ -40,6 +40,7 @@ const mockCveSlaResult = {
               slaBreached: true,
               vulnerabilityId: 'SNYK-001',
               breachedSince: '1 day',
+              fixAvailable: true,
             },
           ],
         },
@@ -69,6 +70,7 @@ const mockProductResult = {
             slaBreached: true,
             vulnerabilityId: 'SNYK-001',
             breachedSince: '1 day',
+            fixAvailable: true,
           },
         ],
       },
@@ -114,18 +116,21 @@ describe('/overdue-vulnerabilities', () => {
         .expect('Content-Type', /application\/json/)
         .expect(200)
         .expect(res => {
-          expect(res.body).toStrictEqual(mockCveSlaResult)
+          expect(res.body).toStrictEqual([
+            {
+              name: 'My Product',
+              numberOfBreachedComponents: 1,
+              numberOfBreachedVulnerabilities: 1,
+              slug: 'product-1',
+              totalComponents: 1,
+            },
+          ])
         })
-    })
-
-    it('should call getCveSlaForServiceArea with the correct slug', async () => {
-      await request(app).get('/overdue-vulnerabilities/hmpps-area').expect(200)
-      expect(cveSlaService.getCveSlaForServiceArea).toHaveBeenCalledWith('hmpps-area')
     })
   })
 
   describe('GET /:serviceAreaSlug/product/:slug', () => {
-    it('should call getCveSlaForServiceArea with the correct slug', async () => {
+    it('should call getCveSlaForProduct with the correct slugs', async () => {
       await request(app).get('/overdue-vulnerabilities/hmpps-area/product/hmpps-product').expect(200)
       expect(cveSlaService.getCveSlaForProduct).toHaveBeenCalledWith('hmpps-area', 'hmpps-product')
     })

--- a/server/routes/vulnerabilitySlas.test.ts
+++ b/server/routes/vulnerabilitySlas.test.ts
@@ -94,7 +94,7 @@ describe('/overdue-vulnerabilities', () => {
       return request(app)
         .get('/overdue-vulnerabilities')
         .expect(302)
-        .expect('Location', 'overdue-vulnerabilities/hmpps-area')
+        .expect('Location', '/overdue-vulnerabilities/hmpps-area')
     })
     it('should error if no service areas', async () => {
       serviceCatalogueService.getServiceAreas = jest.fn().mockResolvedValue([])
@@ -102,7 +102,7 @@ describe('/overdue-vulnerabilities', () => {
     })
     it('should call getServiceAreas with withComponents: false', async () => {
       const result = await request(app).get('/overdue-vulnerabilities').expect(302)
-      expect(result.headers.location).toBe('overdue-vulnerabilities/hmpps-area')
+      expect(result.headers.location).toBe('/overdue-vulnerabilities/hmpps-area')
       expect(serviceCatalogueService.getServiceAreas).toHaveBeenCalledWith({ withComponents: false })
     })
   })

--- a/server/routes/vulnerabilitySlas.test.ts
+++ b/server/routes/vulnerabilitySlas.test.ts
@@ -39,6 +39,7 @@ const mockCveSlaResult = {
               severityLevel: 'HIGH',
               slaBreached: true,
               vulnerabilityId: 'SNYK-001',
+              breachedSince: '1 day',
             },
           ],
         },
@@ -67,6 +68,7 @@ const mockProductResult = {
             severityLevel: 'HIGH',
             slaBreached: true,
             vulnerabilityId: 'SNYK-001',
+            breachedSince: '1 day',
           },
         ],
       },
@@ -86,18 +88,21 @@ afterEach(() => {
   jest.resetAllMocks()
 })
 
-describe('/vulnerability-slas', () => {
+describe('/overdue-vulnerabilities', () => {
   describe('GET /', () => {
     it('should redirect to the first service area slug', async () => {
-      return request(app).get('/vulnerability-slas').expect(302).expect('Location', 'vulnerability-slas/hmpps-area')
+      return request(app)
+        .get('/overdue-vulnerabilities')
+        .expect(302)
+        .expect('Location', 'overdue-vulnerabilities/hmpps-area')
     })
     it('should error if no service areas', async () => {
       serviceCatalogueService.getServiceAreas = jest.fn().mockResolvedValue([])
-      return request(app).get('/vulnerability-slas').expect(500)
+      return request(app).get('/overdue-vulnerabilities').expect(500)
     })
     it('should call getServiceAreas with withComponents: false', async () => {
-      const result = await request(app).get('/vulnerability-slas').expect(302)
-      expect(result.headers.location).toBe('vulnerability-slas/hmpps-area')
+      const result = await request(app).get('/overdue-vulnerabilities').expect(302)
+      expect(result.headers.location).toBe('overdue-vulnerabilities/hmpps-area')
       expect(serviceCatalogueService.getServiceAreas).toHaveBeenCalledWith({ withComponents: false })
     })
   })
@@ -105,7 +110,7 @@ describe('/vulnerability-slas', () => {
   describe('GET /:serviceAreaSlug', () => {
     it('should return JSON CVE SLA data for the given service area', async () => {
       return request(app)
-        .get('/vulnerability-slas/hmpps-area.json')
+        .get('/overdue-vulnerabilities/hmpps-area.json')
         .expect('Content-Type', /application\/json/)
         .expect(200)
         .expect(res => {
@@ -114,14 +119,14 @@ describe('/vulnerability-slas', () => {
     })
 
     it('should call getCveSlaForServiceArea with the correct slug', async () => {
-      await request(app).get('/vulnerability-slas/hmpps-area').expect(200)
+      await request(app).get('/overdue-vulnerabilities/hmpps-area').expect(200)
       expect(cveSlaService.getCveSlaForServiceArea).toHaveBeenCalledWith('hmpps-area')
     })
   })
 
   describe('GET /:serviceAreaSlug/product/:slug', () => {
     it('should call getCveSlaForServiceArea with the correct slug', async () => {
-      await request(app).get('/vulnerability-slas/hmpps-area/product/hmpps-product').expect(200)
+      await request(app).get('/overdue-vulnerabilities/hmpps-area/product/hmpps-product').expect(200)
       expect(cveSlaService.getCveSlaForProduct).toHaveBeenCalledWith('hmpps-area', 'hmpps-product')
     })
   })

--- a/server/services/cveSlaService.test.ts
+++ b/server/services/cveSlaService.test.ts
@@ -11,6 +11,7 @@ const makeVuln = (overrides: Partial<SnykVulnerability> = {}): SnykVulnerability
   snyk_id: 'SNYK-001',
   severity: 'HIGH',
   published_date: '2020-01-01',
+  fix_available: 'true',
   ...overrides,
 })
 
@@ -115,6 +116,7 @@ describe('CveSlaService', () => {
       slaBreached: true,
       vulnerabilityId: '01',
       breachedSince: relativeTimeFromNow(new Date('2020-01-02')),
+      fixAvailable: true,
     }
 
     it('priortises vulnerability count', () => {
@@ -222,6 +224,7 @@ describe('CveSlaService', () => {
                     slaBreached: true,
                     vulnerabilityId: 'SNYK-001',
                     breachedSince: relativeTimeFromNow(new Date(oldDate)),
+                    fixAvailable: true,
                   },
                 ],
               },

--- a/server/services/cveSlaService.test.ts
+++ b/server/services/cveSlaService.test.ts
@@ -74,7 +74,7 @@ describe('CveSlaService', () => {
   })
 
   describe('compare vulnerability info', () => {
-    it('priortises severity', () => {
+    it('prioritises severity', () => {
       const v1 = makeVulnInfo({ vulnerabilityId: 'vuln-1', severityLevel: 'HIGH', publishedDate: '2026-01-01' })
       const v2 = makeVulnInfo({ vulnerabilityId: 'vuln-2', severityLevel: 'CRITICAL', publishedDate: '2026-01-01' })
       const v3 = makeVulnInfo({ vulnerabilityId: 'vuln-3', severityLevel: 'MEDIUM', publishedDate: '2026-01-01' })

--- a/server/services/cveSlaService.test.ts
+++ b/server/services/cveSlaService.test.ts
@@ -1,6 +1,7 @@
 import ServiceCatalogueService from './serviceCatalogueService'
-import CveSlaService, { type ComponentInfo, type ProductInfo } from './cveSlaService'
+import CveSlaService, { Vulnerability, type ComponentInfo, type ProductInfo } from './cveSlaService'
 import { Component, Product, ServiceArea, SnykVulnerability } from '../data/strapiApiTypes'
+import { relativeTimeFromNow } from '../utils/utils'
 
 jest.mock('./serviceCatalogueService')
 
@@ -10,6 +11,14 @@ const makeVuln = (overrides: Partial<SnykVulnerability> = {}): SnykVulnerability
   snyk_id: 'SNYK-001',
   severity: 'HIGH',
   published_date: '2020-01-01',
+  ...overrides,
+})
+
+const makeVulnInfo = (overrides: Partial<Vulnerability> = {}): Vulnerability => ({
+  vulnerabilityId: 'SNYK-001',
+  severityLevel: 'HIGH',
+  publishedDate: '2020-01-01',
+  slaBreached: true,
   ...overrides,
 })
 
@@ -64,12 +73,48 @@ describe('CveSlaService', () => {
     })
   })
 
+  describe('compare vulnerability info', () => {
+    it('priortises severity', () => {
+      const v1 = makeVulnInfo({ vulnerabilityId: 'vuln-1', severityLevel: 'HIGH', publishedDate: '2026-01-01' })
+      const v2 = makeVulnInfo({ vulnerabilityId: 'vuln-2', severityLevel: 'CRITICAL', publishedDate: '2026-01-01' })
+      const v3 = makeVulnInfo({ vulnerabilityId: 'vuln-3', severityLevel: 'MEDIUM', publishedDate: '2026-01-01' })
+
+      const vulnerabilityIds = [v1, v2, v3]
+        .sort(cveSlaService.compareVulnerabilities)
+        .map(vulnerability => vulnerability.vulnerabilityId)
+      expect(vulnerabilityIds).toStrictEqual(['vuln-2', 'vuln-1', 'vuln-3'])
+    })
+
+    it('then by date', () => {
+      const v1 = makeVulnInfo({ vulnerabilityId: 'vuln-1', severityLevel: 'HIGH', publishedDate: '2026-01-01' })
+      const v2 = makeVulnInfo({ vulnerabilityId: 'vuln-2', severityLevel: 'HIGH', publishedDate: '2026-01-03' })
+      const v3 = makeVulnInfo({ vulnerabilityId: 'vuln-3', severityLevel: 'HIGH', publishedDate: '2026-01-02' })
+
+      const vulnerabilityIds = [v1, v2, v3]
+        .sort(cveSlaService.compareVulnerabilities)
+        .map(vulnerability => vulnerability.vulnerabilityId)
+      expect(vulnerabilityIds).toStrictEqual(['vuln-1', 'vuln-3', 'vuln-2'])
+    })
+
+    it('then by name', () => {
+      const v1 = makeVulnInfo({ vulnerabilityId: 'vuln-1', severityLevel: 'HIGH', publishedDate: '2026-01-01' })
+      const v2 = makeVulnInfo({ vulnerabilityId: 'vuln-2', severityLevel: 'HIGH', publishedDate: '2026-01-01' })
+      const v3 = makeVulnInfo({ vulnerabilityId: 'vuln-3', severityLevel: 'HIGH', publishedDate: '2026-01-01' })
+
+      const vulnerabilityIds = [v1, v2, v3]
+        .sort(cveSlaService.compareVulnerabilities)
+        .map(vulnerability => vulnerability.vulnerabilityId)
+      expect(vulnerabilityIds).toStrictEqual(['vuln-1', 'vuln-2', 'vuln-3'])
+    })
+  })
+
   describe('compare component info', () => {
     const vulnerability = {
       publishedDate: '2020-01-02',
       severityLevel: 'HIGH',
       slaBreached: true,
       vulnerabilityId: '01',
+      breachedSince: relativeTimeFromNow(new Date('2020-01-02')),
     }
 
     it('priortises vulnerability count', () => {
@@ -176,6 +221,7 @@ describe('CveSlaService', () => {
                     severityLevel: 'HIGH',
                     slaBreached: true,
                     vulnerabilityId: 'SNYK-001',
+                    breachedSince: relativeTimeFromNow(new Date(oldDate)),
                   },
                 ],
               },

--- a/server/services/cveSlaService.ts
+++ b/server/services/cveSlaService.ts
@@ -97,10 +97,12 @@ export default class CveSlaService {
             publishedDate: vuln.published_date,
             breachedSince: vuln.published_date ? relativeTimeFromNow(new Date(vuln.published_date)) : 'n/a',
             slaBreached: this.slaBreached(vuln.published_date),
+            fixAvailable: String(vuln.fix_available).toLowerCase() === 'true',
           }
         })
-        .sort(this.compareVulnerabilities)
-        ?.filter(vuln => ['HIGH', 'CRITICAL'].includes(vuln.severityLevel)) || []
+        ?.sort(this.compareVulnerabilities)
+        ?.filter(vuln => ['HIGH', 'CRITICAL'].includes(vuln.severityLevel))
+        ?.filter(vuln => vuln.fixAvailable) || []
 
     return {
       name: component.name,

--- a/server/services/cveSlaService.ts
+++ b/server/services/cveSlaService.ts
@@ -133,7 +133,8 @@ export default class CveSlaService {
     const time1 = Date.parse(vuln1.publishedDate)
     const time2 = Date.parse(vuln2.publishedDate)
     const dateComparison =
-      (Number.isNaN(time1) ? Number.POSITIVE_INFINITY : time1) - (Number.isNaN(time2) ? Number.POSITIVE_INFINITY : time2)
+      (Number.isNaN(time1) ? Number.POSITIVE_INFINITY : time1) -
+      (Number.isNaN(time2) ? Number.POSITIVE_INFINITY : time2)
     if (dateComparison !== 0) return dateComparison
     return vuln1.vulnerabilityId.localeCompare(vuln2.vulnerabilityId)
   }

--- a/server/services/cveSlaService.ts
+++ b/server/services/cveSlaService.ts
@@ -130,7 +130,10 @@ export default class CveSlaService {
     const severityOrder = ['LOW', 'MEDIUM', 'HIGH', 'CRITICAL']
     const severityComparison = severityOrder.indexOf(vuln2.severityLevel) - severityOrder.indexOf(vuln1.severityLevel)
     if (severityComparison !== 0) return severityComparison
-    const dateComparison = new Date(vuln1.publishedDate).getTime() - new Date(vuln2.publishedDate).getTime()
+    const time1 = Date.parse(vuln1.publishedDate)
+    const time2 = Date.parse(vuln2.publishedDate)
+    const dateComparison =
+      (Number.isNaN(time1) ? Number.POSITIVE_INFINITY : time1) - (Number.isNaN(time2) ? Number.POSITIVE_INFINITY : time2)
     if (dateComparison !== 0) return dateComparison
     return vuln1.vulnerabilityId.localeCompare(vuln2.vulnerabilityId)
   }

--- a/server/services/cveSlaService.ts
+++ b/server/services/cveSlaService.ts
@@ -2,6 +2,7 @@ import assert from 'assert'
 import ServiceCatalogueService from './serviceCatalogueService'
 import { Component, SnykVulnerability } from '../data/modelTypes'
 import { Product } from '../data/strapiApiTypes'
+import { relativeTimeFromNow } from '../utils/utils'
 
 export type ComponentInfo = ReturnType<CveSlaService['getComponentInfo']>
 export type ProductInfo = {
@@ -9,6 +10,13 @@ export type ProductInfo = {
   slug: string
   components: ComponentInfo[]
   numberOfBreachedComponents: number
+}
+
+export type Vulnerability = {
+  vulnerabilityId: string
+  severityLevel: string
+  publishedDate: string
+  slaBreached: boolean
 }
 
 export default class CveSlaService {
@@ -87,9 +95,11 @@ export default class CveSlaService {
             vulnerabilityId: vuln.snyk_id,
             severityLevel: vuln.severity.toUpperCase(),
             publishedDate: vuln.published_date,
+            breachedSince: vuln.published_date ? relativeTimeFromNow(new Date(vuln.published_date)) : 'n/a',
             slaBreached: this.slaBreached(vuln.published_date),
           }
         })
+        .sort(this.compareVulnerabilities)
         ?.filter(vuln => ['HIGH', 'CRITICAL'].includes(vuln.severityLevel)) || []
 
     return {
@@ -114,5 +124,14 @@ export default class CveSlaService {
   compareProducts(product1: ProductInfo, product2: ProductInfo) {
     const result = product2.numberOfBreachedComponents - product1.numberOfBreachedComponents
     return result !== 0 ? result : product1.name.localeCompare(product2.name)
+  }
+
+  compareVulnerabilities(vuln1: Vulnerability, vuln2: Vulnerability) {
+    const severityOrder = ['LOW', 'MEDIUM', 'HIGH', 'CRITICAL']
+    const severityComparison = severityOrder.indexOf(vuln2.severityLevel) - severityOrder.indexOf(vuln1.severityLevel)
+    if (severityComparison !== 0) return severityComparison
+    const dateComparison = new Date(vuln1.publishedDate).getTime() - new Date(vuln2.publishedDate).getTime()
+    if (dateComparison !== 0) return dateComparison
+    return vuln1.vulnerabilityId.localeCompare(vuln2.vulnerabilityId)
   }
 }

--- a/server/views/pages/index.njk
+++ b/server/views/pages/index.njk
@@ -37,7 +37,7 @@
         <li><a class="govuk-link--no-visited-state" href="/veracode" data-test="veracode-link">Veracode</a></li>
         <li><a class="govuk-link--no-visited-state" href="/snyk-scans" data-test="snyk-link">Snyk scans</a></li>
         <li><a class="govuk-link--no-visited-state" href="/reports/rds" data-test="rds-link">RDS</a></li>
-        <li><a class="govuk-link--no-visited-state" href="/overdue-vulnerabilities" data-test="breached-vulnerability-slas-link">Overdue vulnerabilities</a></li>
+        <li><a class="govuk-link--no-visited-state" href="/overdue-vulnerabilities" data-test="overdue-vulnerabilities-link">Overdue vulnerabilities</a></li>
         <li><a class="govuk-link--no-visited-state" href="/scheduled-jobs" data-test="scheduled-jobs-link">Scheduled discovery jobs</a></li>
       </ul>
     </div>

--- a/server/views/pages/index.njk
+++ b/server/views/pages/index.njk
@@ -35,9 +35,10 @@
       <h2>Reports</h2>
       <ul>
         <li><a class="govuk-link--no-visited-state" href="/veracode" data-test="veracode-link">Veracode</a></li>
-        <li><a class="govuk-link--no-visited-state" href="/snyk-scans" data-test="snyk-link">Snyk Scans</a></li>
+        <li><a class="govuk-link--no-visited-state" href="/snyk-scans" data-test="snyk-link">Snyk scans</a></li>
         <li><a class="govuk-link--no-visited-state" href="/reports/rds" data-test="rds-link">RDS</a></li>
-        <li><a class="govuk-link--no-visited-state" href="/scheduled-jobs" data-test="scheduled-jobs-link">Scheduled Discovery Jobs</a></li>
+        <li><a class="govuk-link--no-visited-state" href="/overdue-vulnerabilities" data-test="breached-vulnerability-slas-link">Overdue vulnerabilities</a></li>
+        <li><a class="govuk-link--no-visited-state" href="/scheduled-jobs" data-test="scheduled-jobs-link">Scheduled discovery jobs</a></li>
       </ul>
     </div>
     <div class="govuk-grid-column-one-half">

--- a/server/views/pages/overdueVulnerabilitiesForProduct.njk
+++ b/server/views/pages/overdueVulnerabilitiesForProduct.njk
@@ -6,6 +6,7 @@
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 {% from "govuk/components/select/macro.njk" import govukSelect %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/accordion/macro.njk" import govukAccordion %}
 
 {% block content %}
 
@@ -37,18 +38,14 @@
     </div>
   </div>
 
-  {% set product = product %}
   <h1>Overdue vulnerabilities for {{ product.name }}</h1>
     <p>{{ product.numberOfBreachedComponents }} / {{ product.components.length }} components have vulnerabilties that have breached their SLA</p>
 
-    {% for component in product.components %}
-      <h3>
-          <a href="/components/{{component.name}}" class="govuk-link--no-visited-state">{{component.name}}</a>
-      </h3>
-      <p>
-        {{ component.breachedVulnerabilities.length }} vulnerabilties with breached SLAs.
-        See all production vulnerabilities <a href="/snyk-scans/{{component.name}}/environments/{{component.scanName}}" class="govuk-link--no-visited-state">here</a>
-      </p>
+
+  {% set items = [] %}
+  {% for component in product.components %}
+    {% set html %}
+      <p>See all production vulnerabilities <a href="/snyk-scans/{{ component.name }}/environments/{{component.scanName}}" class="govuk-link--no-visited-state">here</a></p>
       {% if component.breachedVulnerabilities.length %}
           {% set rows = [] %}
           {% for vuln in component.breachedVulnerabilities %}
@@ -73,11 +70,30 @@
               rows: rows
           }) }}
       {% endif %}
-    {% endfor %}
+    {% endset %}
+
+    {% set items = (items.push({
+      heading: {
+        text: component.name
+      },
+      summary: {
+        html: '<p>' + component.breachedVulnerabilities.length + ' vulnerabilties with breached SLAs present in production for <a href="/components/' +  component.name + '" class="govuk-link--no-visited-state">' + component.name  + '</a>.<br/></p>'
+      },
+      content: {
+        html: html
+      }
+    }), items) %}
+  {% endfor %}
+
+
+    {{ govukAccordion({
+      id: "components",
+      items: items
+    }) }}
 {% endblock %}
 
 {% block bodyEnd %}
   <script type="module" src="/assets/frontendInit.js"></script>
   <script src="/assets/js/common.js"></script>
-  <script src="/assets/js/overdueVulnerabilities.js"></script>
+  <script src="/assets/js/overdueVulnerabilitiesForProduct.js"></script>
 {% endblock %}

--- a/server/views/pages/overdueVulnerabilitiesForProduct.njk
+++ b/server/views/pages/overdueVulnerabilitiesForProduct.njk
@@ -10,8 +10,8 @@
 {% block content %}
 
   {% set breadCrumbList = [
-      {title: "Breached vulnerability SLAs", href: '/vulnerability-slas'},
-      {title: serviceArea.name, href: '/vulnerability-slas/' + serviceArea.slug }
+      {title: "Overdue vulnerabilties", href: '/overdue-vulnerabilities'},
+      {title: serviceArea.name, href: '/overdue-vulnerabilities/' + serviceArea.slug }
     ]
   %}
 
@@ -38,35 +38,37 @@
   </div>
 
   {% set product = product %}
-  <h1>Vulnerability SLAs for {{ product.name }}</h1>
-  {% set info %}
-    <p>This shows products and components that have breached SLA targets for HIGH or CRITICAL vulnerabilities.</p>
-    <p>In line with <a href="https://security-guidance.service.justice.gov.uk/patch-management-guide/#patching-schedule">MoJ guidance</a>, these vulnerabilities are expected to be resolved within 3–7 days.</p>
-    <p>Any flagged components contain HIGH or CRITICAL vulnerabilities that have remained unresolved (or unsuppressed) for more than 7 days since publication.</p>
-    <p>This data is refreshed nightly.</p>
-  {% endset %}
-  {{ govukDetails({
-        summaryText: "About this page",
-        html: info
-  }) }}
-    <p>{{ product.numberOfBreachedComponents }} / {{ product.components.length }} components have breached SLAs</p>
+  <h1>Overdue vulnerabilities for {{ product.name }}</h1>
+    <p>{{ product.numberOfBreachedComponents }} / {{ product.components.length }} components have vulnerabilties that have breached their SLA</p>
 
     {% for component in product.components %}
-      <h3 class="{% if not component.breachedVulnerabilities.length %}no-breaches{% endif %}">{{component.name}}</h3>
-      <p>{{ component.breachedVulnerabilities.length }} vulnerabilties with breached SLAs. See all production vulnerabilities <a href="/snyk-scans/{{component.name}}/environments/{{component.scanName}}" class="govuk-link--no-visited-state">here</a></p>
+      <h3>
+          <a href="/components/{{component.name}}" class="govuk-link--no-visited-state">{{component.name}}</a>
+      </h3>
+      <p>
+        {{ component.breachedVulnerabilities.length }} vulnerabilties with breached SLAs.
+        See all production vulnerabilities <a href="/snyk-scans/{{component.name}}/environments/{{component.scanName}}" class="govuk-link--no-visited-state">here</a>
+      </p>
       {% if component.breachedVulnerabilities.length %}
           {% set rows = [] %}
           {% for vuln in component.breachedVulnerabilities %}
-              {% set rows = (rows.push([{ text: vuln.vulnerabilityId },{ text: vuln.severityLevel }, { text: vuln.publishedDate }]), rows) %}
+              {% set rows = (rows.push([
+                { html: '<a href="https://security.snyk.io/vuln/' + vuln.vulnerabilityId + '" class="govuk-link--no-visited-state">' + vuln.vulnerabilityId + '</a>' },
+                { text: vuln.severityLevel },
+                { text: vuln.publishedDate },
+                { text: vuln.breachedSince }
+                ])
+              , rows) %}
           {% endfor %}
           {{ govukTable({
-              caption: "Breached vulnerabilities",
+              caption: "Overdue vulnerabilities",
               captionClasses: "govuk-table__caption--s",
               firstCellIsHeader: false,
               head: [
                   { text: "Vuln ID" },
                   { text: "Severity Level" },
-                  { text: "Published date" }
+                  { text: "Published date" },
+                  { text: "Overdue since" }
               ],
               rows: rows
           }) }}
@@ -77,5 +79,5 @@
 {% block bodyEnd %}
   <script type="module" src="/assets/frontendInit.js"></script>
   <script src="/assets/js/common.js"></script>
-  <script src="/assets/js/vulnerabilitySlas.js"></script>
+  <script src="/assets/js/overdueVulnerabilities.js"></script>
 {% endblock %}

--- a/server/views/pages/overdueVulnerabilitiesForServiceArea.njk
+++ b/server/views/pages/overdueVulnerabilitiesForServiceArea.njk
@@ -32,7 +32,7 @@
   </div>
 
 
-  <h1>Overdue vulnerabilities for {{ serviceArea.name }}</h1>
+  <h1>Overdue vulnerabilities for {{ serviceAreaName }}</h1>
   {% set info %}
     <p>
       This page highlights products and components with HIGH or CRITICAL security issues that are overdue for fixing.
@@ -45,15 +45,12 @@
     </p>
     <ul>
       <li>is rated <strong>HIGH or CRITICAL</strong>, and</li>
-      <li>is still present more than <strong>7 days after its publication date</strong></li>
+      <li>a fix has been published, and</li>
+      <li>it is still present more than <strong>7 days after its publication date</strong></li>
     </ul>
 
     <p>
-      <strong>Note:</strong> This view does not currently take into account suppressions defined in <code>.snyk</code> files. A <a href="https://dsdmoj.atlassian.net/browse/HEAT-1279">ticket</a> for this is planned.
-    </p>
-
-    <p>
-      Data on this page comes from <a class="govuk-link--no-visited-state" href="/scheduled-jobs/hmpps-snyk-discovery-full">nightly scans of production images</a>.
+      Data on this page comes from <a class="govuk-link--no-visited-state" href="/scheduled-jobs/hmpps-snyk-discovery-full">nightly scans of production images</a> rather than the dependencies associated with the current HEAD of the main branch.
     </p>
   {% endset %}
   {{ govukDetails({
@@ -61,31 +58,28 @@
         html: info
   }) }}
 
-  {% set rows = [] %}
-  {% for product in serviceArea.productsWithComponents %}
-    {% set rows = (rows.push([
-      { html: '<a href="' + serviceArea.slug +'/product/' + product.slug + '" class="govuk-link--no-visited-state">' +product.name },
-      { text: product.numberOfBreachedComponents },
-      { text: product.components.length },
-      { text: product.numberOfBreachedVulnerabilities }]),
-       rows) %}
-  {% endfor %}
-  {{ govukTable({
-      caption: "Products",
-      captionClasses: "govuk-table__caption--l",
-      firstCellIsHeader: false,
-      head: [
-          { html: "Product name" },
-          { text: "Breached components" },
-          { text: "Total components" },
-          { text: "Number of breached vulnerabilities" }
-      ],
-      rows: rows
-  }) }}
+    <table id="products" class="stripe">
+    <thead>
+      <tr>
+        <th>Product name</th>
+        <th class="govuk-!-width-one-fifth">Breached components</th>
+        <th class="govuk-!-width-one-fifth">Total components</th>
+        <th class="govuk-!-width-one-quarter">Number of breached vulnerabilities</th>
+      </tr>
+    </thead>
+    <tfoot>
+      <tr>
+        <th>Product name</th>
+        <th class="govuk-!-width-one-fifth">Breached components</th>
+        <th class="govuk-!-width-one-fifth">Total components</th>
+        <th class="govuk-!-width-one-quarter">Number of breached vulnerabilities</th>
+      </tr>
+    </tfoot>
+  </table>
 {% endblock %}
 
 {% block bodyEnd %}
   <script type="module" src="/assets/frontendInit.js"></script>
   <script src="/assets/js/common.js"></script>
-  <script src="/assets/js/overdueVulnerabilities.js"></script>
+  <script src="/assets/js/overdueVulnerabilitiesForServiceArea.js"></script>
 {% endblock %}

--- a/server/views/pages/overdueVulnerabilitiesForServiceArea.njk
+++ b/server/views/pages/overdueVulnerabilitiesForServiceArea.njk
@@ -9,7 +9,7 @@
 
 {% block content %}
 
-  {{ breadCrumb("Breached vulnerability SLAs", []) }}
+  {{ breadCrumb("Overdue vulnerabilities", []) }}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       {{ govukSelect({
@@ -32,12 +32,29 @@
   </div>
 
 
-  <h1>Vulnerability SLAs for {{ serviceArea.name }}</h1>
+  <h1>Overdue vulnerabilities for {{ serviceArea.name }}</h1>
   {% set info %}
-    <p>This shows products and components that have breached SLA targets for HIGH or CRITICAL vulnerabilities.</p>
-    <p>In line with <a href="https://security-guidance.service.justice.gov.uk/patch-management-guide/#patching-schedule">MoJ guidance</a>, these vulnerabilities are expected to be resolved within 3–7 days.</p>
-    <p>Any flagged components contain HIGH or CRITICAL vulnerabilities that have remained unresolved (or unsuppressed) for more than 7 days since publication.</p>
-    <p>This data is refreshed nightly.</p>
+    <p>
+      This page highlights products and components with HIGH or CRITICAL security issues that are overdue for fixing.
+    </p>
+    <p>
+      Under <a href="https://security-guidance.service.justice.gov.uk/patch-management-guide/#patching-schedule">MoJ guidance</a>, these issues should typically be resolved within <strong>3–7 days</strong>.
+    </p>
+    <p>
+      A security issue is considered overdue if it:
+    </p>
+    <ul>
+      <li>is rated <strong>HIGH or CRITICAL</strong>, and</li>
+      <li>is still present more than <strong>7 days after its publication date</strong></li>
+    </ul>
+
+    <p>
+      <strong>Note:</strong> This view does not currently take into account suppressions defined in <code>.snyk</code> files. A <a href="https://dsdmoj.atlassian.net/browse/HEAT-1279">ticket</a> for this is planned.
+    </p>
+
+    <p>
+      Data on this page comes from <a class="govuk-link--no-visited-state" href="/scheduled-jobs/hmpps-snyk-discovery-full">nightly scans of production images</a>.
+    </p>
   {% endset %}
   {{ govukDetails({
         summaryText: "About this page",
@@ -70,5 +87,5 @@
 {% block bodyEnd %}
   <script type="module" src="/assets/frontendInit.js"></script>
   <script src="/assets/js/common.js"></script>
-  <script src="/assets/js/vulnerabilitySlas.js"></script>
+  <script src="/assets/js/overdueVulnerabilities.js"></script>
 {% endblock %}

--- a/server/views/pages/scheduledJob.njk
+++ b/server/views/pages/scheduledJob.njk
@@ -34,7 +34,17 @@
         </tr>
         <tr>
           <th>Last run errors</th>
-          <td>{{ scheduledJob.error_details }}</a></td>
+          <td>
+            {% if scheduledJob.error_details and scheduledJob.error_details.length is defined and scheduledJob.error_details is not string %}
+               <ul>
+                  {% for error in scheduledJob.error_details %}
+                    <li>{{error}}</li>
+                  {% endfor %}
+                </ul>
+            {% else %}
+              {{ scheduledJob.error_details  }}
+            {% endif %}
+          </td>
         </tr>
       </tbody>
     </table>


### PR DESCRIPTION
- Rename route, views, assets and SCSS from vulnerabilitySlas to overdueVulnerabilities for clearer naming (files, routes, templates, styles)
- Add breachedSince field to vulnerabilities using relativeTimeFromNow utility
- Add compareVulnerabilities sorting (by severity desc, then publish date asc)
- Update scheduledJob view and index page links to use new route names
- Update route and service tests to reflect renames and new functionality